### PR TITLE
Add Apple LED Cinema Display 24"

### DIFF
--- a/acdcontrol.cpp
+++ b/acdcontrol.cpp
@@ -61,6 +61,7 @@ const int CINEMA_DISPLAY_24               = 0x921e;
 const int CINEMA_DISPLAY_27               = 0x9226;
 const int CINEMA_DISPLAY_27_2013          = 0x9227;
 const int CINEMA_DISPLAY_30               = 0x9232;
+const int CINEMA_LED_DISPLAY_24           = 0x9236;
 
 const int S1                              = 0x8002;
 
@@ -547,6 +548,8 @@ void init_device_database() {
                                      "Apple Cinema HD Display 27\"" ));
   supportedDevices.insert( DeviceId( APPLE, CINEMA_DISPLAY_30,
                                      "Apple Cinema HD Display 30\"" ));
+  supportedDevices.insert( DeviceId( APPLE, CINEMA_LED_DISPLAY_24,
+                                     "Apple LED Cinema Display 24\"" ));
 
   supportedDevices.insert( DeviceId( SAMSUNG, S1,
                                      "Samsung SyncMaster 757NF" ));

--- a/acdcontrol.py
+++ b/acdcontrol.py
@@ -24,6 +24,7 @@ SUPPORTED_DEVICES = {
         (0x9226, 'Apple Cinema HD Display 27"'),
         (0x9227, 'Apple Cinema HD Display 27" 2013'),
         (0x9232, 'Apple Cinema HD Display 30"'),
+        (0x9236, 'Apple LED Cinema Display 24"'),
     ),
     (0x0419, 'Samsung Electronics'): (
         (0x8002, 'Samsung SyncMaster 757NF'),


### PR DESCRIPTION
Hi there, I added support for Apple LED Cinema Display 24" with productId `0x9236`.